### PR TITLE
add check for input size

### DIFF
--- a/pem_cert/target.c
+++ b/pem_cert/target.c
@@ -25,12 +25,19 @@
 #include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
+#define WC_MAX_FUZZ_INPUT_SZ 25000
+
 /* testing wolfSSL_CTX_use_certificate_buffer with PEM as the filetype*/
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t sz)
 {
     WOLFSSL_CTX *ctx;
     int          ret;
+
+    /* avoid 25s timeout with parsing large files */
+    if (sz > WS_MAX_FUZZ_INPUT_SZ) {
+        return 0;
+    }
 
     wolfSSL_Init();
 


### PR DESCRIPTION
Added to avoid running for longer than 25 seconds in the case that a very large input buffer is passed in.